### PR TITLE
ProPass Katie

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require_relative './lib/pronounceable_password'
+require 'benchmark'
 pronounce = PronounceablePassword.new './data/probability.csv'
 pronounce.read_probabilities
 pass_length = 10
@@ -17,3 +18,9 @@ while common_pronouncable_password.length < pass_length do
   common_pronouncable_password << pronounce.common_next_letter(common_pronouncable_password.last)
 end
 puts common_pronouncable_password.join
+
+  time = Benchmark.realtime do
+    pronounce.possible_next_letters("t")
+  end
+
+puts "it took #{time * 1000} ms"

--- a/lib/pronounceable_password.rb
+++ b/lib/pronounceable_password.rb
@@ -17,17 +17,14 @@ class PronounceablePassword
     letters = {}
     CSV.foreach(@probability_corpus, headers: true) do |line|
       letters.merge!({line[0] => line[1].to_i})
-
     end
 
     #Array of tupils
     # letters = []
     # CSV.foreach(@probability_corpus, headers: true) do |line|
-
     #   letters.push({line[0] => line[1].to_i})
-
-
     # end
+
     letters
   end
 
@@ -45,10 +42,10 @@ class PronounceablePassword
     #Array of tupils
     # hash = read_probabilities.select do |pair| 
     #   pair.keys[0][0] == letter
-
     # end
 
     # hash.sort_by {|pair| pair.values}.reverse
+    
   end
 
 
@@ -68,7 +65,7 @@ class PronounceablePassword
 
 
     #Hash
-    possible_next_letters(letter).to_h.keys.sample(sample_limit)
+    possible_next_letters(letter).to_h.keys.sample(sample_limit)[0][1]
 
     #Array of tupils
     # pairs = possible_next_letters(letter).sample(sample_limit)

--- a/lib/pronounceable_password.rb
+++ b/lib/pronounceable_password.rb
@@ -1,4 +1,5 @@
 require 'csv'
+require 'pry'
 
 class PronounceablePassword
 
@@ -11,19 +12,70 @@ class PronounceablePassword
   def read_probabilities
     # Should consume the provided CSV file into a structure that
     # can be used to identify the most probably next letter
+
+    #Hash
+    letters = {}
+    CSV.foreach(@probability_corpus, headers: true) do |line|
+      letters.merge!({line[0] => line[1].to_i})
+
+    end
+
+    #Array of tupils
+    # letters = []
+    # CSV.foreach(@probability_corpus, headers: true) do |line|
+
+    #   letters.push({line[0] => line[1].to_i})
+
+
+    # end
+    letters
   end
 
   def possible_next_letters(letter)
     # Should return an array of possible next letters sorted
     # by likelyhood in a descending order
+
+    #Hash
+    hash = read_probabilities.select do |pair| 
+      pair[0] == letter
+    end
+
+    hash.sort_by {|pair| pair[1]}.reverse
+
+    #Array of tupils
+    # hash = read_probabilities.select do |pair| 
+    #   pair.keys[0][0] == letter
+
+    # end
+
+    # hash.sort_by {|pair| pair.values}.reverse
   end
+
 
   def most_common_next_letter(letter)
     # The most probable next letter
+
+    #Hash
+    possible_next_letters(letter).first[0][1]
+
+    #Array of tupils
+    # possible_next_letters(letter).first.first[0][1]
   end
 
   def common_next_letter(letter, sample_limit = 2)
     # Randomly select a common letter within a range defined by
-    # the sample limit as the lower bounds of a substring 
+    # the sample limit as the lower bounds of a substring
+
+
+    #Hash
+    possible_next_letters(letter).to_h.keys.sample(sample_limit)
+
+    #Array of tupils
+    # pairs = possible_next_letters(letter).sample(sample_limit)
+
+    # pairs.first.keys[0][1]
   end
+
+
 end
+

--- a/spec/pronounceable_password_spec.rb
+++ b/spec/pronounceable_password_spec.rb
@@ -11,17 +11,15 @@ describe 'Pronounceable Passwords' do
   end
 
   it 'will load the probability corpus csv' do
-    letter_pairs = ['aa', 'kb', 'za']
     probabilities = @pronounce.read_probabilities
-    probabilities.each do |pair|
-      expect(pair.key['aa']).to equal 1
-      expect(probabilities['kb']).to equal nil
-      expect(probabilities['za']).to equal 26
-    end
+    expect(probabilities['aa']).to equal 1
+    expect(probabilities['kb']).to equal nil
+    expect(probabilities['za']).to equal 26
+
   end
 
   it 'will pick the next most common letters' do
-    expect(@pronounce.possible_next_letters('z')).to eql ({"za" => 26, "zb" => 10})
+    expect(@pronounce.possible_next_letters('z')).to eql ([["za", 26], ["zb", 10]])
   end
 
   it 'will pick the next best letter' do

--- a/spec/pronounceable_password_spec.rb
+++ b/spec/pronounceable_password_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require_relative './spec_helper'
 require_relative './custom_expectations'
 require_relative '../lib/pronounceable_password'
@@ -10,14 +11,17 @@ describe 'Pronounceable Passwords' do
   end
 
   it 'will load the probability corpus csv' do
+    letter_pairs = ['aa', 'kb', 'za']
     probabilities = @pronounce.read_probabilities
-    expect(probabilities['aa']).to equal 1
-    expect(probabilities['kb']).to equal nil
-    expect(probabilities['za']).to equal 26
+    probabilities.each do |pair|
+      expect(pair.key['aa']).to equal 1
+      expect(probabilities['kb']).to equal nil
+      expect(probabilities['za']).to equal 26
+    end
   end
 
   it 'will pick the next most common letters' do
-    expect(@pronounce.possible_next_letters('z')).to eql [{"za"=>26}, {"zb"=>10}]
+    expect(@pronounce.possible_next_letters('z')).to eql ({"za" => 26, "zb" => 10})
   end
 
   it 'will pick the next best letter' do


### PR DESCRIPTION
So I tried using just a hash and using an array of mini hashs (tupils) when parsing out the data. I used the Benchmark ruby class to test which way is faster. They were both pretty much the same. From my own research, I expected that the hash would be faster, because how ruby indexes the keys in a hash when storing the key, value pair. Where as with the array of tupils you have to iterate over the array until you find the correct pair. 

Instead of using a while loop in the driver you could use the each iterator on a range. Something like: (0..pass_length).each 
